### PR TITLE
Update interfaces

### DIFF
--- a/build-armbian/common-files/rootfs/etc/network/interfaces
+++ b/build-armbian/common-files/rootfs/etc/network/interfaces
@@ -1,5 +1,5 @@
 source /etc/network/interfaces.d/*
 # Network is managed by Network manager
-auto eth0
+#auto eth0
+allow-hotplug eth0
 iface eth0 inet dhcp
-        hwaddress ether 12:34:56:78:9A:BC


### PR DESCRIPTION
This will start interface eth0 when the kernel detects a hotplug event from the interface (i.e. when you plug a cable in), instead of starting it at boot.