### PR TITLE
Add MobileBox M401A support (format)

### DIFF
--- a/build-armbian/common-files/rootfs/etc/amlogic_model_database.conf
+++ b/build-armbian/common-files/rootfs/etc/amlogic_model_database.conf
@@ -70,7 +70,7 @@
 303     :MECOOL-KM3-4G               :s905x2   :meson-g12a-sei510.dtb                  :u-boot-x96max.bin            :x96max-u-boot.bin.sd.bin            :NA                           :meson-g12a    :s905x2-km3  :yes
 304     :E900V22C-D                  :s905l3a  :meson-g12a-s905l3a-e900v22c.dtb        :u-boot-e900v22c.bin          :NA                                  :NA                           :meson-g12a    :s905l3a     :yes
 305     :CM311-1a-YST                :s905l3a  :meson-g12a-s905l3a-cm311.dtb           :u-boot-e900v22c.bin          :NA                                  :NA                           :meson-g12a    :s905l3a     :no
-306     :M401A                       :s905l3a  :meson-g12a-u200.dtb                    :u-boot-e900v22c.bin          :NA                                  :NA                           :meson-g12a    :s905l3a     :no
+306     :M401A                       :s905l3a  :meson-g12a-s905l3a-m401a.dtb           :u-boot-e900v22c.bin          :NA                                  :NA                           :meson-g12a    :s905l3a     :no
 
 
 # Amlogic G12B Family


### PR DESCRIPTION
m401a写入emmc时暂时用u-boot-e900v22c.bin了,（5.15.x下没问题，6.0.x下可emmc启动，但不能usb引导了，如改为u-boot-u200.bin，则不能emmc启动，但能usb引导)，待后续制作专用uboot（或者修改boot.cmd？）