### PR TITLE
Copy snap symbol links on armbian-install.

### DIFF
--- a/build-armbian/armbian-files/platform-files/amlogic/rootfs/usr/sbin/armbian-install
+++ b/build-armbian/armbian-files/platform-files/amlogic/rootfs/usr/sbin/armbian-install
@@ -488,6 +488,19 @@ copy_rootfs() {
         )
         sync
     done
+    # Copy snap directory if necessary
+    SNAP_SRC="snap"
+    for src in ${SNAP_SRC}; do
+        if [ -d ${src} ]; then
+            echo -e "${INFO} Copy snap directory [ ${src} ]."
+            # Copy symbol links with depth of no more than 2
+            tar -cf - `find ${src} -maxdepth 2 -type l` | (
+                cd ${DIR_INSTALL}
+                tar -xf -
+            )
+        fi
+        sync
+    done
     # Create relevant symbolic link
     ln -sf /usr/bin ${DIR_INSTALL}/bin
     ln -sf /usr/lib ${DIR_INSTALL}/lib


### PR DESCRIPTION
With the previous change of `/tmp`, `snapd` can be installed to both TF and eMMC. But when I ran `armbian-install` on a TF card with `snapd` installed, symbol links in `/snap` were not copied to eMMC.

```
~$ find /snap -maxdepth 2 -type l
/snap/core20/current
/snap/bin/lxd.lxc-to-lxd
/snap/bin/lxd.buginfo
/snap/bin/lxd.benchmark
/snap/bin/lxc
/snap/bin/lxd.check-kernel
/snap/bin/lxd.lxc
/snap/bin/lxd.migrate
/snap/bin/lxd
/snap/core/current
/snap/snapd/current
/snap/bare/current
/snap/lxd/current
```

So I patched `armbian-install` to copy these symbol links.