### PR TITLE
use `uname` instead `arch` to detect architecture

### DIFF
--- a/rebuild
+++ b/rebuild
@@ -60,7 +60,7 @@ tmp_build="${tmp_dir}/tmp_build"
 tmp_aml_image="${tmp_dir}/tmp_aml_image"
 
 # System operation environment
-arch_info="$(arch)"
+arch_info="$(uname -m)"
 host_release="$(cat /etc/os-release | grep '^VERSION_CODENAME=.*' | cut -d'=' -f2)"
 # Get armbian ${VERSION_CODENAME}: such as [ jammy ]
 os_release_file="etc/os-release"


### PR DESCRIPTION
on arch linux `arch` command doesn't exists