### PR TITLE
adjust for magic box UNT402A with soc s905L

### DIFF
--- a/build-armbian/armbian-files/common-files/etc/model_database.conf
+++ b/build-armbian/armbian-files/common-files/etc/model_database.conf
@@ -65,7 +65,8 @@
 122     :IP103H,TY1608                 :s905l3b  :meson-gxl-s905l3b-m302a.dtb            :u-boot-s905x-s912.bin        :NA                                  :NA                              :2+8G,100Mb-Nic                             :stable        :amlogic     :meson-gxl    :uEnv.txt        :s905l3b-ip103h      :no
 123     :BesTV-R3300L,SumaVision-Q7    :s905lb   :meson-gxl-s905x-p212.dtb               :u-boot-r3300l.bin            :r3300l-u-boot.bin.sd.bin            :NA                              :2+8G,100Mb-Nic                             :stable        :amlogic     :meson-gxl    :extlinux.conf   :s905lb-r3300l       :yes
 124     :Q96-mini                      :s905lb   :meson-gxl-s905x-p212.dtb               :u-boot-s905x-s912.bin        :NA                                  :NA                              :1G/8G,100Mb-Nic                            :stable        :amlogic     :meson-gxl    :uEnv.txt        :s905lb-q96-mini     :no
-125     :UNT402A			:s905l	:meson-gxl-s905l3b-m302a.dtb            :u-boot-p212.bin        :NA                                  :NA                              :2+8G,100Mb-Nic                             :stable        :amlogic     :meson-gxl    :uEnv.txt        :s905l             :yes
+125     :UNT402A                       :s905l    :meson-gxl-s905l3b-m302a.dtb            :u-boot-p212.bin              :NA                                  :NA                              :2+8G,100Mb-Nic                             :stable        :amlogic     :meson-gxl    :uEnv.txt        :s905l-unt402A       :yes
+
 
 # Amlogic GXM Family
 #-------+------------------------------+---------+---------------------------------------+-----------------------------+------------------------------------+--------------------------------+-------------------------------------------+--------------+------------+-------------+----------------+--------------------+----------

--- a/build-armbian/armbian-files/common-files/etc/model_database.conf
+++ b/build-armbian/armbian-files/common-files/etc/model_database.conf
@@ -65,7 +65,7 @@
 122     :IP103H,TY1608                 :s905l3b  :meson-gxl-s905l3b-m302a.dtb            :u-boot-s905x-s912.bin        :NA                                  :NA                              :2+8G,100Mb-Nic                             :stable        :amlogic     :meson-gxl    :uEnv.txt        :s905l3b-ip103h      :no
 123     :BesTV-R3300L,SumaVision-Q7    :s905lb   :meson-gxl-s905x-p212.dtb               :u-boot-r3300l.bin            :r3300l-u-boot.bin.sd.bin            :NA                              :2+8G,100Mb-Nic                             :stable        :amlogic     :meson-gxl    :extlinux.conf   :s905lb-r3300l       :yes
 124     :Q96-mini                      :s905lb   :meson-gxl-s905x-p212.dtb               :u-boot-s905x-s912.bin        :NA                                  :NA                              :1G/8G,100Mb-Nic                            :stable        :amlogic     :meson-gxl    :uEnv.txt        :s905lb-q96-mini     :no
-
+125     :UNT402A			:s905l	:meson-gxl-s905l3b-m302a.dtb            :u-boot-p212.bin        :NA                                  :NA                              :2+8G,100Mb-Nic                             :stable        :amlogic     :meson-gxl    :uEnv.txt        :s905l             :yes
 
 # Amlogic GXM Family
 #-------+------------------------------+---------+---------------------------------------+-----------------------------+------------------------------------+--------------------------------+-------------------------------------------+--------------+------------+-------------+----------------+--------------------+----------


### PR DESCRIPTION
1、在6.1stable最新内核下测试通过；
2、测试使用u-boot-p212.bin完美适配6.1核心的启动和emmc/usb系统切换，（u-boot-s905x-s912.bin 写入emmc后没法常规方法从usb启动）。
3、6.1内核下使用armbian-install 或 armbian-install -m yes 均可以正常写入使用；
4、暂时配置成独立打包的镜像模式，O大可根据具体空间现状调整一下策略；
5、后续如有需要独立dtb分离，emmc频率应该调整到50 000 000左右为合适。