### PR TITLE
rebuild: do not preserve ownership when copying from armbian-files

### DIFF
--- a/rebuild
+++ b/rebuild
@@ -729,24 +729,24 @@ copy_files() {
     cp -af ${tmp_armbian}/* ${tag_rootfs}
 
     # Copy the common files
-    [[ -d "${common_files}" ]] && cp -af ${common_files}/* ${tag_rootfs}
+    [[ -d "${common_files}" ]] && cp -af --no-preserve=ownership ${common_files}/* ${tag_rootfs}
 
     # Copy the platform files
     platform_bootfs="${platform_files}/${PLATFORM}/bootfs"
     platform_rootfs="${platform_files}/${PLATFORM}/rootfs"
     [[ -d "${platform_bootfs}" ]] && cp -rf ${platform_bootfs}/* ${tag_bootfs}
-    [[ -d "${platform_rootfs}" ]] && cp -af ${platform_rootfs}/* ${tag_rootfs}
+    [[ -d "${platform_rootfs}" ]] && cp -af --no-preserve=ownership ${platform_rootfs}/* ${tag_rootfs}
 
     # Copy the different files
     different_bootfs="${different_files}/${board}/bootfs"
     different_rootfs="${different_files}/${board}/rootfs"
     [[ -d "${different_bootfs}" ]] && cp -rf ${different_bootfs}/* ${tag_bootfs}
-    [[ -d "${different_rootfs}" ]] && cp -af ${different_rootfs}/* ${tag_rootfs}
+    [[ -d "${different_rootfs}" ]] && cp -af --no-preserve=ownership ${different_rootfs}/* ${tag_rootfs}
 
     # Copy the bootloader files
     [[ -d "${tag_rootfs}/usr/lib/u-boot" ]] || mkdir -p ${tag_rootfs}/usr/lib/u-boot
     rm -rf ${tag_rootfs}/usr/lib/u-boot/*
-    [[ -d "${bootloader_path}" ]] && cp -af ${bootloader_path}/* ${tag_rootfs}/usr/lib/u-boot
+    [[ -d "${bootloader_path}" ]] && cp -af --no-preserve=ownership ${bootloader_path}/* ${tag_rootfs}/usr/lib/u-boot
 
     # Copy the overload files
     [[ "${PLATFORM}" == "amlogic" ]] && cp -rf ${uboot_path}/${PLATFORM}/overload/* ${tag_bootfs}


### PR DESCRIPTION
the current build script copies certain files under `build-armbian/ armbian-files` into the target rootfs, using command and argument `cp -af`, between the arguments, `-a` expands to `-dR --preserve=all`, the problem then arises due to `all` metadata being preserved, which includes the ownership.

since the build script is always run as root, the builder will then copy those files owned by the initial non-root runner, in this case the github actions runner default user, as root. root is powerful, and `cp` is then able to preserve the file ownership as the runner non-root user, which results in `/etc`, `/lib32`, etc owned by the non-existing `1001:123` uid:gid in the target image, this is bad and will break the system.

adding argument `--no-preserve=ownership` should fix the problem, the no-preserve argument takes priority before `--preserve`, there- fore ownership won't be preserved anymore.

ref: https://www.gnu.org/software/coreutils/manual/coreutils.html#cp-invocation

fixes #1563