### PR TITLE
Add support for nexbox-a95x (s905x)

### DIFF
--- a/.github/workflows/build-armbian.yml
+++ b/.github/workflows/build-armbian.yml
@@ -85,6 +85,7 @@ on:
           - s905x-t95
           - s905x-tbee
           - s905x-tx9
+          - s905x-nexbox-a95x
           - s905x2
           - s905x2-km3
           - s905x2-x96max-2g

--- a/.github/workflows/rebuild-armbian.yml
+++ b/.github/workflows/rebuild-armbian.yml
@@ -79,6 +79,7 @@ on:
           - s905x-t95
           - s905x-tbee
           - s905x-tx9
+          - s905x-nexbox-a95x
           - s905x2
           - s905x2-km3
           - s905x2-x96max-2g

--- a/.github/workflows/use-releases-file-to-build.yml
+++ b/.github/workflows/use-releases-file-to-build.yml
@@ -85,6 +85,7 @@ on:
           - s905x-t95
           - s905x-tbee
           - s905x-tx9
+          - s905x-nexbox-a95x
           - s905x2
           - s905x2-km3
           - s905x2-x96max-2g

--- a/build-armbian/armbian-files/common-files/etc/model_database.conf
+++ b/build-armbian/armbian-files/common-files/etc/model_database.conf
@@ -73,6 +73,7 @@
 #-------+-----------------------------------+---------+---------------------------------------+-----------------------------+------------------------------------+--------------------------------+-------------------------------------------+--------------+------------+-------------+----------------+--------------------------------------+--------------------+----------
 126     :UNT402A,M201-S                     :s905l    :meson-gxl-s905l3b-m302a.dtb            :u-boot-p212.bin              :NA                                  :NA                              :2+8G,100Mb-Nic                             :stable        :amlogic     :meson-gxl    :uEnv.txt        :janko888,hzlyu123                     :s905l               :yes
 127     :S65                                :s905mb   :meson-gxl-s905x-p212.dtb               :u-boot-r3300l.bin            :r3300l-u-boot.bin.sd.bin            :NA                              :2+8G,100Mb-Nic                             :stable        :amlogic     :meson-gxl    :extlinux.conf   :shijifeizhai                          :s905mb              :no
+128     :Nexbox-a95x                        :s905x    :meson-gxl-s905x-nexbox-a95x.dtb        :u-boot-s905x-s912.bin        :NA                                  :NA                              :2+8G,100Mb-Nic                             :stable        :amlogic     :meson-gxl    :uEnv.txt        :khancyr                               :s905x               :no
 
 
 # Amlogic GXM Family


### PR DESCRIPTION
Add support for nexbox-a95x (s905x).
Working fine.
EMMC is working
Eth is working
usb and sd support is working
I haven't used wifi nor IR nor SPIF