### PR TITLE
优化代理支持，用 curl 代替 wget 命令。

### DIFF
--- a/rebuild
+++ b/rebuild
@@ -480,7 +480,7 @@ download_kernel() {
                     echo -e "${INFO} (${x}.${i}) [ ${k} - ${kernel_var} ] Kernel download from [ ${kernel_down_from} ]"
 
                     mkdir -p ${kernel_path}/${kd}
-                    wget "${kernel_down_from}" -q -P "${kernel_path}/${kd}"
+                    curl -sL "${kernel_down_from}" -o "${kernel_path}/${kd}/${kernel_var}.tar.gz"
                     [[ "${?}" -ne "0" ]] && error_msg "Failed to download the kernel files from the server."
 
                     tar -mxzf "${kernel_path}/${kd}/${kernel_var}.tar.gz" -C "${kernel_path}/${kd}"


### PR DESCRIPTION
SOCKS5 代理支持方式

提前配置好代理，默认需要配置到 root 用户生效。

```
git config --global http.proxy 'socks5://127.0.0.1:1080'
export ALL_PROXY="socks5h://127.0.0.1:1080"
```
