### PR TITLE
Use ${GITHUB_REPOSITORY}/${GITHUB_REF_NAME} instead of hardcode repository name and ref

### DIFF
--- a/.github/workflows/build-armbian.yml
+++ b/.github/workflows/build-armbian.yml
@@ -276,7 +276,7 @@ jobs:
           df -hT ${PWD}
           git clone -q --single-branch --depth=1 --branch=main https://github.com/armbian/build.git build
           ln -sf /builder/build ${GITHUB_WORKSPACE}/build
-          ln -sf /builder/build /home/runner/work/_actions/ophub/amlogic-s9xxx-armbian/main/build
+          ln -sf /builder/build /home/runner/work/_actions/${GITHUB_REPOSITORY}/${GITHUB_REF_NAME}/build
           echo "status=success" >> ${GITHUB_OUTPUT}
 
       - name: Compile Armbian [ ${{ inputs.set_release }} ]

--- a/.github/workflows/compile-kernel.yml
+++ b/.github/workflows/compile-kernel.yml
@@ -131,8 +131,8 @@ jobs:
         run: |
           df -hT ${PWD}
           mkdir -p /builder/{kernel,output}
-          ln -sf /builder/kernel /home/runner/work/_actions/ophub/amlogic-s9xxx-armbian/main/compile-kernel/kernel
-          ln -sf /builder/output /home/runner/work/_actions/ophub/amlogic-s9xxx-armbian/main/compile-kernel/output
+          ln -sf /builder/kernel /home/runner/work/_actions/${GITHUB_REPOSITORY}/${GITHUB_REF_NAME}/compile-kernel/kernel
+          ln -sf /builder/output /home/runner/work/_actions/${GITHUB_REPOSITORY}/${GITHUB_REF_NAME}/compile-kernel/output
           echo "status=success" >> ${GITHUB_OUTPUT}
 
       - name: Compile the kernel [ ${{ inputs.kernel_version }} ]

--- a/.github/workflows/rebuild-armbian.yml
+++ b/.github/workflows/rebuild-armbian.yml
@@ -294,7 +294,7 @@ jobs:
 
           mkdir -p /builder/build
           ln -sf /builder/build ${GITHUB_WORKSPACE}/build
-          ln -sf /builder/build /home/runner/work/_actions/ophub/amlogic-s9xxx-armbian/main/build
+          ln -sf /builder/build /home/runner/work/_actions/${GITHUB_REPOSITORY}/${GITHUB_REF_NAME}/build
 
           sudo timedatectl set-timezone "${TZ}"
           echo "build_tag=Armbian${set_release}_${{ inputs.armbian_storage }}_$(date +"%Y.%m")" >> ${GITHUB_OUTPUT}

--- a/.github/workflows/use-releases-file-to-build.yml
+++ b/.github/workflows/use-releases-file-to-build.yml
@@ -275,7 +275,7 @@ jobs:
           armbian_buildpath="build/output/images"
           [[ -d "${armbian_buildpath}" ]] || mkdir -p "${armbian_buildpath}"
           ln -sf /builder/build ${GITHUB_WORKSPACE}/build
-          ln -sf /builder/build /home/runner/work/_actions/ophub/amlogic-s9xxx-armbian/main/build
+          ln -sf /builder/build /home/runner/work/_actions/${GITHUB_REPOSITORY}/${GITHUB_REF_NAME}/build
 
           latest_version="$(curl -s \
                               -H "Accept: application/vnd.github+json" \


### PR DESCRIPTION
unable to read `GITHUB_ACTION_PATH` so use `/home/runner/work/_actions${GITHUB_REPOSITORY}/${GITHUB_REF_NAME}` instead
https://docs.github.com/en/actions/learn-github-actions/variables