### PR TITLE
解决rebuild 情况创建绝对链接

### DIFF
--- a/rebuild
+++ b/rebuild
@@ -919,13 +919,13 @@ refactor_rootfs() {
     rm -f etc/update-motd.d/50-motd-news
 
     # Rebuild symbolic link files (ln -sf ${target} ${symbolic_link_file})
-    ln -sf /usr/bin bin
-    ln -sf /usr/lib lib
-    ln -sf /usr/sbin sbin
-    ln -sf /run/lock var/lock
-    ln -sf /run var/run
-    ln -sf /usr/share/zoneinfo/Asia/Shanghai etc/localtime
-    ln -sf /usr/sbin/armbian-ddbr usr/sbin/ddbr
+    ln -sf usr/bin bin
+    ln -sf usr/lib lib
+    ln -sf usr/sbin sbin
+    ln -sf ../run/lock var/lock
+    ln -sf ../run var/run
+    ln -sf ../usr/share/zoneinfo/Asia/Shanghai etc/localtime
+    ln -sf armbian-ddbr usr/sbin/ddbr
 
     # Fix common releases permissions
     [[ -d "var/tmp" ]] && chmod 777 var/tmp


### PR DESCRIPTION
在某些情况下，软件安装时会检查/bin、/lib等链接是否是相对链接。如果异常，系统将无法安装软件包。

测试环境: debian testing