### PR TITLE
Change kernel build symlinks to use repo owner's path (not HC path)

### DIFF
--- a/.github/workflows/compile-kernel.yml
+++ b/.github/workflows/compile-kernel.yml
@@ -137,8 +137,8 @@ jobs:
         run: |
           df -hT ${PWD}
           mkdir -p /builder/{kernel,output}
-          ln -sf /builder/kernel /home/runner/work/_actions/ophub/amlogic-s9xxx-armbian/main/compile-kernel/kernel
-          ln -sf /builder/output /home/runner/work/_actions/ophub/amlogic-s9xxx-armbian/main/compile-kernel/output
+          ln -sf /builder/kernel /home/runner/work/_actions/${GITHUB_REPOSITORY_OWNER}/amlogic-s9xxx-armbian/main/compile-kernel/kernel
+          ln -sf /builder/output /home/runner/work/_actions/${GITHUB_REPOSITORY_OWNER}/amlogic-s9xxx-armbian/main/compile-kernel/output
           echo "status=success" >> ${GITHUB_OUTPUT}
 
       - name: Compile the kernel [ ${{ inputs.kernel_version }} ]


### PR DESCRIPTION
The kernel compilation workflow currently fails in forked repositories due to hardcoded /ophub/ paths in the symlink creation.

This PR replaces them with ${GITHUB_REPOSITORY_OWNER} to make sure the kernel build and output directories are correctly linked in the GitHub Actions workspace, regardless of who owns the fork.

Tested in a forked repository to verify the workflow completes successfully.