### PR TITLE
Add dependency check for GCC plugins

### DIFF
--- a/compile-kernel/tools/script/ubuntu_chroot_armbian.sh
+++ b/compile-kernel/tools/script/ubuntu_chroot_armbian.sh
@@ -83,6 +83,11 @@ check_dependencies() {
         gzip | *) necessary_packages="gzip" ;;
     esac
 
+    if  grep -q '^CONFIG_GCC_PLUGINS.*=y' "${armbian_kernel_path}/.config" && # Check if plugins are enabled
+        grep -q '^CONFIG_GCC_PLUGIN_.*=y' "${armbian_kernel_path}/.config"; then # Check if at least one plugin is enabled
+        necessary_packages+=" libmpc-dev libgmp3-dev"
+    fi
+
     # Install the necessary packages
     trap 'error_msg "Failed to install required dependencies."' ERR
     [[ -n "$(dpkg -l | awk '{print $2}' | grep -w "^${necessary_packages}$")" ]] || {


### PR DESCRIPTION
When building the kernel with any GCC plugin enabled (`CONFIG_GCC_PLUGIN_*`) two dependencies, `libmpc-dev` and `libgmp3-dev` are added. This PR adds a dependency check that will install the two dependencies within the Armbian system.