### PR TITLE
Update start_service.sh to support disabling the LED display correctly

### DIFF
--- a/build-armbian/armbian-files/common-files/etc/custom_service/start_service.sh
+++ b/build-armbian/armbian-files/common-files/etc/custom_service/start_service.sh
@@ -109,9 +109,11 @@ fi
 # Led display control
 openvfd_enable="no"
 openvfd_boxid="15"
-openvfd_config="15"
-if [[ "${openvfd_enable}" == "yes" && -n "${openvfd_boxid}" && -n "${openvfd_config}" && -x "/usr/sbin/armbian-openvfd" ]]; then
-    (armbian-openvfd "${openvfd_boxid}" && armbian-openvfd "${openvfd_config}") &
+if [[ -n "${openvfd_boxid}" && "${openvfd_boxid}" != 0 && -x "/usr/sbin/armbian-openvfd" ]]; then
+    (armbian-openvfd "${openvfd_boxid}") &
+    if [[ "${openvfd_enable}" == "no" ]]; then
+        (armbian-openvfd 0) &
+    fi
     log_message "OpenVFD service execution attempted."
 fi
 

--- a/documents/led_screen_display_control.md
+++ b/documents/led_screen_display_control.md
@@ -31,7 +31,6 @@ vfd_gpio_dat='0,69,0'
 # Execute the following command in the terminal to enable the openvfd service
 sed -i 's|^#*openvfd_enable=.*|openvfd_enable="yes"|g' /etc/custom_service/start_service.sh
 sed -i 's|^#*openvfd_boxid=.*|openvfd_boxid="15"|g' /etc/custom_service/start_service.sh
-sed -i 's|^#*openvfd_config=.*|openvfd_config="15"|g' /etc/custom_service/start_service.sh
 ```
 
 - Everyone is welcome to test and share their device's configuration file (diy.conf) to benefit more people.


### PR DESCRIPTION
This config updates start_service.sh to support disabling the LED display properly on some devices (e.g. A95X F3 Air).
Before booting, the LED screen is set to `BOOT` and running `armbian-openvfd 0` doesn't clear it since it just kills the openvfd service.
We need to run `armbian-openvfd <boxid>` to take control of the display then `armbian-openvfd 0` to clear it and kill openvfd.

I also updated the docs to mention this. The CN instructions is GPT'd but seems correct to me. Any help on that is appreciated.