### PR TITLE
armbian-install: fix eMMC installation for s905x devices

### DIFF
--- a/build-armbian/armbian-files/platform-files/amlogic/rootfs/usr/sbin/armbian-install
+++ b/build-armbian/armbian-files/platform-files/amlogic/rootfs/usr/sbin/armbian-install
@@ -364,14 +364,21 @@ create_partition() {
     fi
 
     # Use the ampart partition tool
+    # Skip ampart on s905x: its stock bootloader (e.g. B860H/HG680P) accesses fixed
+    # eMMC offsets (such as the u-boot env at [ 628 MiB ]) regardless of the
+    # partition table, so the ampart layout starting at [ 117 MiB ] cannot be used.
     AMPART_STATUS="no"
-    [[ -x "/usr/bin/ampart" && "${use_ampart}" == "yes" ]] && {
+    [[ -x "/usr/bin/ampart" && "${use_ampart}" == "yes" && "${AMLOGIC_SOC}" != "s905x" ]] && {
         ampart_tool
         [[ "${?}" -eq "0" ]] && AMPART_STATUS="yes" && echo -e "${STEPS} Successfully repartitioned eMMC with ampart."
     }
 
     # Set partition size (Unit: MiB)
-    if [[ "${AMPART_STATUS}" == "yes" ]]; then
+    if [[ "${AMLOGIC_SOC}" == "s905x" ]]; then
+        BLANK1="700" # s905x stock bootloader uses fixed offsets in the first [ 700 MiB ], must be reserved.
+        BOOT="512"
+        BLANK2="0"
+    elif [[ "${AMPART_STATUS}" == "yes" ]]; then
         BLANK1="117" # After using the ampart to part disk, space after [ 117 MiB ] could be used.
         BOOT="512"
         BLANK2="0"
@@ -387,10 +394,6 @@ create_partition() {
         BLANK1="68"
         BOOT="512"
         BLANK2="220"
-    elif [[ "${AMLOGIC_SOC}" == "s905x" ]]; then
-        BLANK1="700"
-        BOOT="512"
-        BLANK2="0"
     elif [[ "${AMLOGIC_SOC}" == "s905l3a" && "${boxid}" -eq "304" ]]; then
         BLANK1="570" # e900v22c/d: The first [ 570 MiB ] is not writable.
         BOOT="512"


### PR DESCRIPTION
## Problem

Installing to eMMC with `armbian-install` on s905x devices (B860H, HG680P, etc.) completes successfully but the box never boots from eMMC afterwards.

## Root cause

The script already reserves the first 700 MiB for s905x, but that branch is unreachable in practice: when ampart succeeds (default `-a yes`), `AMPART_STATUS == yes` takes priority and the boot partition is created at **117 MiB**.

The stock bootloader on s905x boxes accesses fixed eMMC offsets regardless of the partition table. Verified on a ZTE B860H (S905X):

- The stock u-boot environment lives at the hardcoded offset **628 MiB** (0x27400000) — inside the FAT boot partition of the 117 MiB layout.
- After `ampart --mode dclone data::-1:4`, the EPT places `env` at 116–124 MiB and `data` from 132 MiB, so a partition starting at 117 MiB even overlaps the EPT env region; `saveenv` from the stock autoscripts can corrupt the boot filesystem.

This matches long-standing community findings that the first 700–1000 MiB must be preserved on these boxes (e.g. the Armbian forum B860H thread), and matches unifreq/openwrt_packit, which uses `BLANK1=700` for s905x and does not use ampart for this SoC.

## Fix

- Skip ampart when `AMLOGIC_SOC == s905x`.
- Give the s905x `BLANK1=700` sizing branch precedence over the `AMPART_STATUS` branch, so the reserved area is honored even if ampart is forced.

Other SoCs are unaffected.

## Testing

Tested on a ZTE B860H (S905X, 8G eMMC, stock ZTE bootloader, Armbian bookworm 6.12.93-ophub):

- Before: install with ampart layout (boot partition at 117 MiB) → does not boot from eMMC.
- After: install with this fix (boot partition at 700 MiB, ampart skipped) → boots from eMMC with the stock bootloader via `emmc_autoscript`, no `u-boot.ext`/`u-boot.emmc` needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)